### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ And then execute:
 
     $ bundle
 
-Or install it yourself as:
+Or install it yourself (recommended if you use `bundle install --path vendor/bundle`):
 
     $ gem install githooks
 


### PR DESCRIPTION
I usually do:

```
$ bundle install --path vendor/bundle
```

and then did:

```
$ bundle exec githooks --init
```

This did not work:

```
$ git commit -m 'cc'
/home/xxx/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- githooks (LoadError)
  from /home/xxx/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
  from .git/hooks/pre-commit:3:in `<main>'
```

But...

```
$ gem install githooks
Fetching: githooks-0.0.6.gem (100%)
Successfully installed githooks-0.0.6
1 gem installed

$ git commit -m 'cc'
executed in pre commit hook
[front 2a93749] cc
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 cos.txt
```

I suggest warning about it in the README.
